### PR TITLE
INTYG-8471/INTYGFV-10875: Revert JedisPool aktivering

### DIFF
--- a/redis-cache/core/src/main/java/se/inera/intyg/infra/rediscache/core/BasicCacheConfiguration.java
+++ b/redis-cache/core/src/main/java/se/inera/intyg/infra/rediscache/core/BasicCacheConfiguration.java
@@ -130,8 +130,6 @@ public class BasicCacheConfiguration {
             sentinelConfig = sentinelConfig.sentinel(hosts.get(a), Integer.parseInt(ports.get(a)));
         }
 
-        JedisConnectionFactory factory = new JedisConnectionFactory(sentinelConfig);
-        factory.setUsePool(true);
-        return factory;
+        return new JedisConnectionFactory(sentinelConfig);
     }
 }


### PR DESCRIPTION
INTYG-8471: (INTYGFV-10875) Revert "INTYG-8471: Aktivera JedisPool för JedisConnectionFactory vid redis-sentinel"

This reverts commit 8d6ff6e8

Detta konfigureras under huven av spring-data-redis.