### PR TITLE
K1J-1853: Remove profile pu-integration-intyg-proxy-service

### DIFF
--- a/integration/pu-integration-intyg-proxy-service/src/main/java/se/inera/intyg/infra/pu/integration/intygproxyservice/service/PUIntegrationService.java
+++ b/integration/pu-integration-intyg-proxy-service/src/main/java/se/inera/intyg/infra/pu/integration/intygproxyservice/service/PUIntegrationService.java
@@ -3,7 +3,6 @@ package se.inera.intyg.infra.pu.integration.intygproxyservice.service;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 import se.inera.intyg.infra.pu.integration.api.model.PersonSvar;
 import se.inera.intyg.infra.pu.integration.api.services.PUService;
@@ -11,7 +10,6 @@ import se.inera.intyg.schemas.contract.Personnummer;
 
 @Service
 @RequiredArgsConstructor
-@Profile("pu-integration-intyg-proxy-service")
 public class PUIntegrationService implements PUService {
 
     private final GetPersonIntegrationService getPersonIntegrationService;


### PR DESCRIPTION
Identified that I missed this when working on rehabstod and removing all logic related to old pu-integration and feature toggling related to replacing it with the intyg-proxy-service integration